### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/preprocess_csv/preprocessData.py
+++ b/preprocess_csv/preprocessData.py
@@ -105,7 +105,7 @@ def stemmed(words):
         try:
             stemmed_words.append(st.stem(w))
         except:
-            print("WARN: cannot stem '%s'" % (w))
+            print("WARN: cannot stem '{0!s}'".format((w)))
     return stemmed_words
 
 
@@ -127,7 +127,7 @@ def remove_punctuation(words):
     """Remove punctuation
     """
 
-    punct_regex = re.compile('[%s]' % re.escape(string.punctuation))
+    punct_regex = re.compile('[{0!s}]'.format(re.escape(string.punctuation)))
     nopunct_words = []
     for w in words:
         nw = punct_regex.sub(u'', w)
@@ -148,11 +148,11 @@ def remove_numbers(words):
 
 
 if __name__ == "__main__":
-    print("%s - %s\n" % (os.path.basename(sys.argv[0]), __version__))
+    print("{0!s} - {1!s}\n".format(os.path.basename(sys.argv[0]), __version__))
     (options, args) = parse_command_line(sys.argv)
     if len(args) < 2:
-        print("Usage: %s [options] <CSV input file>" %
-              os.path.basename(sys.argv[0]))
+        print("Usage: {0!s} [options] <CSV input file>".format(
+              os.path.basename(sys.argv[0])))
         sys.exit(-1)
 
     print(options)
@@ -163,8 +163,8 @@ if __name__ == "__main__":
         if options.append:
             o = open(options.outfile, 'ab' if options.append else 'wb')
         else:
-            overwrite = raw_input("File '%s' exists, overwrite? (Y/n): " %
-                                  options.outfile).lower() != 'n'
+            overwrite = raw_input("File '{0!s}' exists, overwrite? (Y/n): ".format(
+                                  options.outfile)).lower() != 'n'
             if overwrite:
                 o = open(options.outfile, 'wb')
             else:
@@ -173,15 +173,15 @@ if __name__ == "__main__":
     f = open(args[1])
     reader = csv.DictReader(f)
     if options.column not in reader.fieldnames:
-        print("ERROR: Specified text column not found ('%s')" % options.column)
-        print("There are following columns in '%s' :-" % args[1])
+        print("ERROR: Specified text column not found ('{0!s}')".format(options.column))
+        print("There are following columns in '{0!s}' :-".format(args[1]))
         for c in reader.fieldnames:
-            print "- %s" % (c)
+            print "- {0!s}".format((c))
         sys.exit()
 
     ncols = len(reader.fieldnames)
     if options.keep:
-        cols = reader.fieldnames + ['<cleaned>%s' % options.column]
+        cols = reader.fieldnames + ['<cleaned>{0!s}'.format(options.column)]
     else:
         cols = reader.fieldnames
     writer = csv.DictWriter(o, cols)
@@ -192,16 +192,16 @@ if __name__ == "__main__":
     for r in reader:
         if i % 100 == 0:
             if i < options.begin - 1:
-                print("Skipped row: %d" % i)
+                print("Skipped row: {0:d}".format(i))
             else:
-                print("Cleaning row: %d" % i)
+                print("Cleaning row: {0:d}".format(i))
         i += 1
         if i < options.begin:
             continue
         if options.end != 0 and i > options.end:
             break
         if len(r) != ncols:
-            print("WARN: row #%d is corrupted" % i)
+            print("WARN: row #{0:d} is corrupted".format(i))
             continue
         if randint(0, 100) > options.random:
             continue
@@ -226,11 +226,11 @@ if __name__ == "__main__":
             # Stemmed
             words = stemmed(words)
         if options.keep:
-            r['<cleaned>%s' % options.column] = ' '.join(words)
+            r['<cleaned>{0!s}'.format(options.column)] = ' '.join(words)
         else:
             r[options.column] = ' '.join(words)
         writer.writerow(r)
         count += 1
-    print("Complete total: %d rows" % count)
+    print("Complete total: {0:d} rows".format(count))
     f.close()
     o.close()

--- a/subset/SubsetData.py
+++ b/subset/SubsetData.py
@@ -96,10 +96,10 @@ def DataReport(filename, labelColumn, options):
     with open(filename) as f:
         reader = csv.DictReader(f)
         if labelColumn not in reader.fieldnames:
-            print("ERROR: Specified label column not found ('%s')" % labelColumn)
-            print("There are following columns in '%s' :-" % filename)
+            print("ERROR: Specified label column not found ('{0!s}')".format(labelColumn))
+            print("There are following columns in '{0!s}' :-".format(filename))
             for c in reader.fieldnames:
-                print "- %s" % (c)
+                print "- {0!s}".format((c))
             return
         count = 0
         all_labels = dict()
@@ -107,9 +107,9 @@ def DataReport(filename, labelColumn, options):
         for i, r in enumerate(reader):
             if i % 10000 == 0:
                 if i < options.begin - 1:
-                    print("Skipped: #%d" % i)
+                    print("Skipped: #{0:d}".format(i))
                 else:
-                    print("Processed: %d" % i)
+                    print("Processed: {0:d}".format(i))
             if i < options.begin - 1:
                 continue
             if options.end != 0 and i >= options.end:
@@ -136,23 +136,23 @@ def DataReport(filename, labelColumn, options):
                 count += 1
         print("-"*80)
         print("================================ Data Report ================================")
-        print("Label column: '%s' (delimiter: '%s')" % (labelColumn,
+        print("Label column: '{0!s}' (delimiter: '{1!s}')".format(labelColumn,
                                                         options.delimiter))
-        print("Total Number of labeled articles: %d" % (count))
-        print("Number of distinct labels: %d" % (len(all_labels)))
+        print("Total Number of labeled articles: {0:d}".format((count)))
+        print("Number of distinct labels: {0:d}".format((len(all_labels))))
         n = 0
         for l in sorted(all_labels, key=all_labels.get, reverse=True):
             n += all_labels[l]
-            print("%-70s %6d" % (l, all_labels[l]))
+            print("{0:<70!s} {1:6d}".format(l, all_labels[l]))
         print("============================== Label Statistics ==============================")
-        print("Maximum number of multiple labels: %d" %
-              sorted(nlabels.keys())[-1])
+        print("Maximum number of multiple labels: {0:d}".format(
+              sorted(nlabels.keys())[-1]))
         for n in nlabels:
             print '-'*80
-            print("N = %d (%d articles)" % (n, nlabels[n].count))
+            print("N = {0:d} ({1:d} articles)".format(n, nlabels[n].count))
             for l in sorted(nlabels[n].labels, key=nlabels[n].labels.get,
                             reverse=True):
-                print("%-70s %6d" % (l, nlabels[n].labels[l]))
+                print("{0:<70!s} {1:6d}".format(l, nlabels[n].labels[l]))
         print("-"*80)
 
 
@@ -190,22 +190,22 @@ def StratifiedSample(data, nperlabel):
     sortedgrp = datagrp.size().order(ascending=False)
     for i, l in enumerate(sortedgrp.index):
         if sortedgrp[l] > nperlabel:
-            print("==> %-50s %6d" % (l, sortedgrp[l]))
+            print("==> {0:<50!s} {1:6d}".format(l, sortedgrp[l]))
             sample = sample.append(RandomSample(data[data['label'] == l],
                                    nperlabel))
         else:
             break
-    print("There are %d labels have more than %d articles" % (i, nperlabel))
-    print("Sample size: %s articles" % (len(sample)))
+    print("There are {0:d} labels have more than {1:d} articles".format(i, nperlabel))
+    print("Sample size: {0!s} articles".format((len(sample))))
     return sample
 
 
 if __name__ == "__main__":
-    print("%s - %s\n" % (os.path.basename(sys.argv[0]), __version__))
+    print("{0!s} - {1!s}\n".format(os.path.basename(sys.argv[0]), __version__))
     (options, args) = parse_command_line(sys.argv)
     if len(args) < 2:
-        print("Usage: %s [options] <CSV input file>" %
-              os.path.basename(sys.argv[0]))
+        print("Usage: {0!s} [options] <CSV input file>".format(
+              os.path.basename(sys.argv[0])))
         sys.exit(-1)
 
     print(options)
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         print("Data analysis in progress...")
         DataReport(args[1], options.column, options)
 
-    print("Reading CSV file...(%s)" % args[1])
+    print("Reading CSV file...({0!s})".format(args[1]))
     data = pd.read_csv(args[1], usecols=[options.column])
     data.columns = ['label']
     # Subsetting data by --begin and --end option
@@ -223,13 +223,13 @@ if __name__ == "__main__":
     data = data[options.begin - 1:options.end]
     data = SelectRows(data, options)
     if options.size != 0:
-        print("Random sampling...(N = %d)" % options.size)
+        print("Random sampling...(N = {0:d})".format(options.size))
         data = RandomSample(data, options.size)
     if options.nperlabel != 0:
-        print("Stratified sampling...(N per label = %d)" % options.nperlabel)
+        print("Stratified sampling...(N per label = {0:d})".format(options.nperlabel))
         data = StratifiedSample(data, options.nperlabel)
 
-    print("Writing output CSV file...(%s)" % options.outfile)
+    print("Writing output CSV file...({0!s})".format(options.outfile))
     if options.selected_cols: 
         columns = [c.strip() for c in
                    options.selected_cols.split(options.delimiter)
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         try:
             outdata = pd.read_csv(args[1], usecols=columns)
         except Exception as e:
-            print("ERROR: Cannot read CSV file (%s)" % e.message)
+            print("ERROR: Cannot read CSV file ({0!s})".format(e.message))
             sys.exit(-1)
     else:
         outdata = pd.read_csv(args[1])

--- a/tdm/tdm.py
+++ b/tdm/tdm.py
@@ -23,10 +23,10 @@ def TDMReport(vec, X, opts):
                            'sum': np.asarray(X.sum(axis=0)).ravel().tolist()})
     freq_df['ratio'] = freq_df['sum']/np.sum(freq_df['sum'])
 
-    print("Total terms: %d" % len(vec.vocabulary_))
-    print("Most frequent %d terms: " % opts.n_freq)
+    print("Total terms: {0:d}".format(len(vec.vocabulary_)))
+    print("Most frequent {0:d} terms: ".format(opts.n_freq))
     print freq_df.sort('sum', ascending=False).head(opts.n_freq)
-    print("Most sparse %d terms: " % opts.n_sparse)
+    print("Most sparse {0:d} terms: ".format(opts.n_sparse))
     print freq_df.sort('sum', ascending=True).head(opts.n_sparse)
 
     return freq_df
@@ -53,10 +53,10 @@ def TFIDFReport(vec, X, opts):
                            'sum': np.asarray(X.sum(axis=0)).ravel().tolist()})
     freq_df['ratio'] = freq_df['sum']/np.sum(freq_df['sum'])
 
-    print("Total terms: %d" % len(vec.vocabulary_))
-    print("Most frequent %d terms: " % opts.n_freq)
+    print("Total terms: {0:d}".format(len(vec.vocabulary_)))
+    print("Most frequent {0:d} terms: ".format(opts.n_freq))
     print freq_df.sort('sum', ascending=False).head(opts.n_freq)
-    print("Most sparse %d terms: " % opts.n_sparse)
+    print("Most sparse {0:d} terms: ".format(opts.n_sparse))
     print freq_df.sort('sum', ascending=True).head(opts.n_sparse)
 
     return freq_df
@@ -165,14 +165,14 @@ def parse_command_line(argv):
 
 
 if __name__ == "__main__":
-    print("%s - %s\n" % (os.path.basename(sys.argv[0]), __version__))
+    print("{0!s} - {1!s}\n".format(os.path.basename(sys.argv[0]), __version__))
     (opts, args) = parse_command_line(sys.argv)
     if len(args) < 2:
-        print("Usage: %s [options] <CSV input file>" %
-              os.path.basename(sys.argv[0]))
+        print("Usage: {0!s} [options] <CSV input file>".format(
+              os.path.basename(sys.argv[0])))
         sys.exit(-1)
 
-    print("Options: %s" % opts)
+    print("Options: {0!s}".format(opts))
 
     opts.remove_terms = []
 
@@ -181,10 +181,10 @@ if __name__ == "__main__":
             opts.remove_terms = pd.read_csv(opts.remove_terms_file,
                                             header=None)[0].tolist()
         except:
-            print("WARN: Cannot read remove terms file (%s)" %
-                  opts.remove_terms_file)
+            print("WARN: Cannot read remove terms file ({0!s})".format(
+                  opts.remove_terms_file))
 
-    print("Reading input file...(%s)" % args[1])
+    print("Reading input file...({0!s})".format(args[1]))
     cols = [opts.textColumn] + opts.labelColumns.split(opts.delimiter)
     df = pd.read_csv(args[1], usecols=cols)
     print("Creating Term Document Matrix...")
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     ext_cols = opts.labelColumns.split(opts.delimiter)
     out_df = out_df[cols].join(pd.DataFrame(df[ext_cols]))
     if opts.out_tdm_file:
-        print("Saving TDM output to CSV file... (%s)" % opts.out_tdm_file)
+        print("Saving TDM output to CSV file... ({0!s})".format(opts.out_tdm_file))
         out_df.to_csv(opts.out_tdm_file, index_label='index')
     if opts.use_tfidf:
         print("Creating TF-IDF Matrix...")
@@ -209,7 +209,7 @@ if __name__ == "__main__":
         cols = out_df.columns - n_sparses - n_frequents
         out_df = out_df[cols].join(pd.DataFrame(df[ext_cols]))
         if opts.out_tfidf_file:
-            print("Saving TF-IDF output to CSV file... (%s)" %
-                  opts.out_tfidf_file)
+            print("Saving TF-IDF output to CSV file... ({0!s})".format(
+                  opts.out_tfidf_file))
             out_df.to_csv(opts.out_tfidf_file, index_label='index')
     print("Done!!!")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:text-as-data?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:text-as-data?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
